### PR TITLE
Add support for file kwarg and __aiostr__ magic method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,24 @@
 
 # Usage
 ```python
-import aioprint
 import asyncio
+import sys
+
+import aioprint
+
+
+class A:
+    async def __aiostr__(self):
+        # The __aiostr__ magic method is preferred
+        # over the __str__ method to provide
+        # a coroutine interface
+        return "pony trick yasuo"
 
 async def main():
-    await print("yes")
-    await print(["sub", 2, "pew"], flush=True, end="")
+    await print(["sub", 2, "pew"], "he is great", end="", sep="LOL")
+    a = A()
+    await print("error", file=sys.stderr)
+    await print(a, file="out.txt")
 
 loop = asyncio.get_event_loop()
 loop.run_until_complete(main())

--- a/aioprint/print.py
+++ b/aioprint/print.py
@@ -1,17 +1,50 @@
 import sys
 from asyncio import get_event_loop
+from io import StringIO, TextIOWrapper
 
+import aiofiles
 from aiofiles.threadpool.binary import AsyncBufferedIOBase
 
-async_stdout_buffer = AsyncBufferedIOBase(
-    sys.stdout, loop=get_event_loop(), executor=None
-)
+_loop = get_event_loop()
+async_stdout_buffer = AsyncBufferedIOBase(sys.stdout, loop=_loop, executor=None)
+
+async_stderr_buffer = AsyncBufferedIOBase(sys.stderr, loop=_loop, executor=None)
 
 # Exact signature like the actual print() function
-async def print(*objects, sep=" ", end="\n", flush=False):
-    """Asynchronously prints things!"""
-    objects = [str(i) for i in objects]
+async def print(*objects, sep=" ", end="\n", flush=False, file=sys.stdout):
+    """
+    Asynchronously prints things!
+    Parameters to be printed will be converted to strings in the following order:
+        - If it has a coroutine function called "__aiostr__", that will be used. It should return a string
+        - Else, it will use the builtin str() (and therefore "__str__" or "__repr__")
+    """
+    # check if it's a buffer we know
+    if file == sys.stdout:
+        buffer = async_stdout_buffer
+        close = False
+    elif file == sys.stderr:
+        buffer = async_stderr_buffer
+        close = False
+    elif isinstance(file, StringIO):
+        # it is a buffer, convert it
+        buffer = AsyncBufferedIOBase(file, loop=_loop, executor=None)
+        close = True
+    elif isinstance(file, TextIOWrapper):
+        # it is an open file, BAD! open async again
+        name = file.name
+        buffer = await aiofiles.open(name, "w")
+        close = True
+    else:
+        # we assume a filename
+        buffer = await aiofiles.open(file, "w")
+        close = True
+    objects = [
+        str(i) if not hasattr(i, "__aiostr__") else await i.__aiostr__()
+        for i in objects
+    ]
     printable_string = f"{sep.join(objects)}{end}"
-    await async_stdout_buffer.write(printable_string)
+    await buffer.write(printable_string)
     if flush:
-        await async_stdout_buffer.flush()
+        await buffer.flush()
+    if close:
+        await buffer.close()


### PR DESCRIPTION
This prefers the `__aiostr__` magic method over the `__str__` method and adds support for a file kwarg.
If the file kwarg is a buffer, it'll write to it. If it's stderr or stdout, it'll write to that, too. If it's a file opened with `open()`, it will re-open it with aiofiles to write there asynchronously. If it's a string, it will open that file and write there.

Sorry for the PR, there is a new example in the README