### PR TITLE
Use Cython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.c
 
 # Distribution / packaging
 .Python
@@ -25,6 +26,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+*.whl
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/aioprint/print.py
+++ b/aioprint/print.py
@@ -6,8 +6,8 @@ import aiofiles
 from aiofiles.threadpool.binary import AsyncBufferedIOBase
 
 _loop = get_event_loop()
-async_stdout_buffer = AsyncBufferedIOBase(sys.stdout, loop=_loop, executor=None)
 
+async_stdout_buffer = AsyncBufferedIOBase(sys.stdout, loop=_loop, executor=None)
 async_stderr_buffer = AsyncBufferedIOBase(sys.stderr, loop=_loop, executor=None)
 
 # Exact signature like the actual print() function

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-import setuptools
+from distutils.core import setup
+
+import setuptools  # noqa
+from Cython.Build import cythonize
 
 with open("README.md", "r") as f:
     long_description = f.read()
@@ -6,7 +9,7 @@ with open("README.md", "r") as f:
 with open("requirements.txt", "r") as f:
     install_requires = f.read().splitlines()
 
-setuptools.setup(
+setup(
     name="aioprint",
     version="0.0.3",
     description="Provides an asynchronous interface for print() using aiofiles.",
@@ -15,7 +18,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="MIT",
-    packages=setuptools.find_packages(),
+    ext_modules=cythonize("aioprint/*.py", compiler_directives={"language_level": "3"}),
     install_requires=install_requires,
     classifiers=[
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
I've modified setup.py to use Cython for speeding up the overall printing. I was unable to write a test case to check the actual speedup that would be accurate, as printing does not like to be timed.

Review would be great. setuptools.setup did not work with Cython, I had to use distutils.